### PR TITLE
Fix parse errros for large numbers that use scientific notation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export class TinyFloat {
   }
 
   /**
-   * Parses the number or it's string representation to BigInt.
+   * Parses the number or its string representation to BigInt.
    *
    * @param num - The number or string representation
    * @param precision - The precision
@@ -201,7 +201,7 @@ export class TinyFloat {
         );
       }
     } else {
-      // scientific notation (typically ≤ 1e-7, ≥ 1e+21)
+      // Scientific notation (typically ≤ 1e-7, ≥ 1e+21)
       const mantissa = str.slice(0, exponentIdx);
       const exponent = Number.parseInt(str.slice(exponentIdx + 1));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,9 +174,9 @@ export class TinyFloat {
   }
 
   /**
-   * Parses the number string to BigInt.
+   * Parses the number or it's string representation to BigInt.
    *
-   * @param str - The number string
+   * @param num - The number or string representation
    * @param precision - The precision
    *
    * @returns The BigInt representation of the number
@@ -185,22 +185,36 @@ export class TinyFloat {
    */
   private parse(num: string | number): bigint {
     let str = num.toString();
-    // Numbers less that 0.000001 are converted to exponential notation, we\
-    // want to keep the dot notation
-    if (typeof num === "number" && num < 0.000001 && num > -0.000001)
-      str = num.toLocaleString("en-US", {
-        maximumFractionDigits: this.precision,
-        useGrouping: false,
-      });
     const digits = this.precision + 1;
     const point = str.indexOf(".");
-    if (point === -1) {
-      return BigInt(str + "0".repeat(digits));
+
+    const exponentIdx = str.indexOf("e");
+    if (exponentIdx === -1) {
+      if (point === -1) {
+        return BigInt(str + "0".repeat(digits));
+      } else {
+        const floatPart = str.slice(point + 1, point + 1 + digits);
+        return BigInt(
+          str.slice(0, point) +
+            floatPart +
+            "0".repeat(digits - floatPart.length)
+        );
+      }
     } else {
-      const floatPart = str.slice(point + 1, point + 1 + digits);
-      return BigInt(
-        str.slice(0, point) + floatPart + "0".repeat(digits - floatPart.length)
-      );
+      // scientific notation (typically ≤ 1e-7, ≥ 1e+21)
+      const mantissa = str.slice(0, exponentIdx);
+      const exponent = Number.parseInt(str.slice(exponentIdx + 1));
+
+      if (point === -1) {
+        return BigInt(mantissa + "0".repeat(digits + exponent));
+      } else {
+        const mantissaFloat = mantissa.slice(point + 1);
+        return BigInt(
+          mantissa.slice(0, point) +
+            mantissaFloat +
+            "0".repeat(digits + exponent - mantissaFloat.length)
+        );
+      }
     }
   }
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -23,6 +23,13 @@ describe("TinyFloat", () => {
     );
   });
 
+  it("accepts scientific notation", () => {
+    expect(new TinyFloat(0.000000000123456).toNumber()).toBe(0.000000000123456); // 1.23456e-10
+    expect(new TinyFloat(1234560000000000000000).toNumber()).toBe(
+      1234560000000000000000
+    ); // 1.23456e+21
+  });
+
   it("accepts tiny float", () => {
     expect(new TinyFloat(new TinyFloat("0")).toNumber()).toBe(0);
     expect(new TinyFloat(new TinyFloat("1")).toNumber()).toBe(1);

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -24,10 +24,8 @@ describe("TinyFloat", () => {
   });
 
   it("accepts scientific notation", () => {
-    expect(new TinyFloat(0.000000000123456).toNumber()).toBe(0.000000000123456); // 1.23456e-10
-    expect(new TinyFloat(1234560000000000000000).toNumber()).toBe(
-      1234560000000000000000
-    ); // 1.23456e+21
+    expect(new TinyFloat(1.23456e-10).toNumber()).toBe(1.23456e-10);
+    expect(new TinyFloat(1.23456e21).toNumber()).toBe(1.23456e21);
   });
 
   it("accepts tiny float", () => {


### PR DESCRIPTION
- adds general logic to handle parsing numbers scientific notation
- removes my previous solution that was handling only very small numbers that use scientific notation